### PR TITLE
Javascript unload fix

### DIFF
--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -61,7 +61,7 @@
 
       <div class="col-md-4">
           <ul class="large_expense">
-            <li><span class="small_dollar">$</span><span class="big_number"><%= total_expense_amount_sphere(@sphere)%></span></li>
+            <li><span class="small_dollar">$</span><span class="big_number"><%= number_to_currency(total_expense_amount_sphere(@sphere))%></span></li>
             <li class="total_expense">total expenses</li>
           </ul>
       </div>
@@ -106,7 +106,7 @@
           lineThickness:0,
           tickLength:0,
           labelFontColor: "#EEEFF0",
-          
+
       },
       axisY:{
           gridThickness:0,
@@ -152,7 +152,7 @@ var chart5 = new CanvasJS.Chart("chartContainer5",
           {
           type: "stackedBar",
           legendText: "<%= cat["name"] %>",
-          
+
           dataPoints: [
 
           <% usernames_per_sphere(@id).each do |user|%>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -83,7 +83,7 @@ $<%= total_expense_amount_sphere(@sphere)%>
 
 
 <script type="text/javascript">
-  window.onload = function () {
+  function init() {
 
     CanvasJS.addColorSet("colorShades",
     [
@@ -166,7 +166,10 @@ var chart5 = new CanvasJS.Chart("chartContainer5",
 
 chart5.render();
 chart1.render();
+
 }
+window.onload = init();
+
 </script>
 
 <hr>

--- a/app/views/spheres/index.html.erb
+++ b/app/views/spheres/index.html.erb
@@ -23,6 +23,7 @@
 </div>
 
 <footer>
+  <div id="footerShow" style="display:none;">
     <div class="row">
       <div class="col-md-4">
         <ul class="left_footer_info">
@@ -52,10 +53,11 @@
 
       </div>
     </div>
+  </div>
   </footer>
 
   <script type="text/javascript">
-    window.onload = function () {
+    function init() {
 
       CanvasJS.addColorSet("grayShades",
       [
@@ -94,6 +96,9 @@
          ]
       });
 
+  chart.render();
+  }
+
   function onMouseover(e) {
     var divId = "." + e.dataPoint.x;
     var divShowId = "."+ e.dataPoint.x +"-show a";
@@ -109,8 +114,8 @@
 
     var sphereUrl = $(divShowId).attr('href');
     $('.view_button a').attr("href", sphereUrl);
+    $('#footerShow').show();
+  }
 
-  }
-  chart.render();
-  }
+  window.onload = init();
   </script>


### PR DESCRIPTION
No longer required to hit refresh to load chart.

Made init() and called windows.onload = init()
